### PR TITLE
Getting current IP information from DNS dig

### DIFF
--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -4,19 +4,34 @@
 USERNAME=username
 PASSWORD=password
 HOST=hostsite
-LOGFILE=logdir/noip.log
-STOREDIPFILE=configdir/current_ip
+LOGDIR=logdir             # best to use full absolute path
+CONFIGDIR=configdir       # best to use full absolute path
+LOGFILE=$LOGDIR/noip.log
+STOREDIPFILE=$CONFIGDIR/current_ip
 USERAGENT="Simple Bash No-IP Updater/0.4 antoniocs@gmail.com"
 
+# create directories if not exist
+mkdir -p $LOGDIR
+mkdir -p $CONFIGDIR
+
+# create file to hold current ip
 if [ ! -e $STOREDIPFILE ]; then
 	touch $STOREDIPFILE
 fi
 
+# get current public ip from remote server
 NEWIP=$(wget -O - http://icanhazip.com/ -o /dev/null)
-STOREDIP=$(cat $STOREDIPFILE)
-# sudo apt install dnsutils
-STOREDIP=$(dig $HOST | grep $HOST | tail -n 1 | cut -f 5)
 
+# verify if dnsutils (dig command) is available
+if ! type "dig" > /dev/null; then
+  # no dig, using fallback on file storage
+  STOREDIP=$(cat $STOREDIPFILE)
+elif
+  # use dig to get local dns record
+  STOREDIP=$(dig $HOST | grep $HOST | tail -n 1 | cut -f 5)
+fi
+
+# compare if ip has changed from the last time (avoiding unnecessary updates on no-ip)
 if [ "$NEWIP" != "$STOREDIP" ]; then
 	RESULT=$(wget -O "$LOGFILE" -q --user-agent="$USERAGENT" --no-check-certificate "https://$USERNAME:$PASSWORD@dynupdate.no-ip.com/nic/update?hostname=$HOST&myip=$NEWIP")
 
@@ -29,4 +44,3 @@ fi
 echo $LOGLINE >> $LOGFILE
 
 exit 0
-

--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -4,8 +4,8 @@
 USERNAME=username
 PASSWORD=password
 HOST=hostsite
-LOGDIR=logdir             # best to use full absolute path
-CONFIGDIR=configdir       # best to use full absolute path
+LOGDIR=logdir             # best to use full absolute path (because of crontab integration)
+CONFIGDIR=configdir       # best to use full absolute path (because of crontab integration)
 LOGFILE=$LOGDIR/noip.log
 STOREDIPFILE=$CONFIGDIR/current_ip
 USERAGENT="Simple Bash No-IP Updater/0.4 antoniocs@gmail.com"

--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -25,6 +25,7 @@ NEWIP=$(wget -O - http://icanhazip.com/ -o /dev/null)
 # verify if dnsutils (dig command) is available
 if ! type "dig" > /dev/null; then
   # no dig, using fallback on file storage
+  # on Debian/Ubuntu based systems, install package with: sudo apt install dnsutils
   STOREDIP=$(cat $STOREDIPFILE)
 elif
   # use dig to get local dns record

--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -14,6 +14,8 @@ fi
 
 NEWIP=$(wget -O - http://icanhazip.com/ -o /dev/null)
 STOREDIP=$(cat $STOREDIPFILE)
+# sudo apt install dnsutils
+STOREDIP=$(dig $HOST | grep $HOST | tail -n 1 | cut -f 5)
 
 if [ "$NEWIP" != "$STOREDIP" ]; then
 	RESULT=$(wget -O "$LOGFILE" -q --user-agent="$USERAGENT" --no-check-certificate "https://$USERNAME:$PASSWORD@dynupdate.no-ip.com/nic/update?hostname=$HOST&myip=$NEWIP")


### PR DESCRIPTION
The current script is very good! But sometimes it happens to fail after the IP is updated locally at configdir/current_ip, and it assumes no-ip has been successfully updated. This changes allows to dig from DNS and keep updating until IP effectively changes.