### PR TITLE
Use no-ip's automatic IP detection instead of icanhazip.com.

### DIFF
--- a/noipupdater.sh
+++ b/noipupdater.sh
@@ -7,40 +7,14 @@ HOST=hostsite
 LOGDIR=logdir             # best to use full absolute path (because of crontab integration)
 CONFIGDIR=configdir       # best to use full absolute path (because of crontab integration)
 LOGFILE=$LOGDIR/noip.log
-STOREDIPFILE=$CONFIGDIR/current_ip
 USERAGENT="Simple Bash No-IP Updater/0.4 antoniocs@gmail.com"
 
 # create directories if not exist
 mkdir -p $LOGDIR
 mkdir -p $CONFIGDIR
 
-# create file to hold current ip
-if [ ! -e $STOREDIPFILE ]; then
-	touch $STOREDIPFILE
-fi
-
-# get current public ip from remote server
-NEWIP=$(wget -O - http://icanhazip.com/ -o /dev/null)
-
-# verify if dnsutils (dig command) is available
-if ! type "dig" > /dev/null; then
-  # no dig, using fallback on file storage
-  # on Debian/Ubuntu based systems, install package with: sudo apt install dnsutils
-  STOREDIP=$(cat $STOREDIPFILE)
-else
-  # use dig to get local dns record
-  STOREDIP=$(dig $HOST | grep $HOST | tail -n 1 | cut -f 5)
-fi
-
-# compare if ip has changed from the last time (avoiding unnecessary updates on no-ip)
-if [ "$NEWIP" != "$STOREDIP" ]; then
-	RESULT=$(wget -O "$LOGFILE" -q --user-agent="$USERAGENT" --no-check-certificate "https://$USERNAME:$PASSWORD@dynupdate.no-ip.com/nic/update?hostname=$HOST&myip=$NEWIP")
-
-	LOGLINE="[$(date +"%Y-%m-%d %H:%M:%S")] $RESULT"
-	echo $NEWIP > $STOREDIPFILE
-else
-	LOGLINE="[$(date +"%Y-%m-%d %H:%M:%S")] No IP change"
-fi
+RESULT=$(wget -O "-" --user-agent="$USERAGENT" --no-check-certificate "https://$USERNAME:$PASSWORD@dynupdate.no-ip.com/nic/update?hostname=$HOST")
+LOGLINE="[$(date +"%Y-%m-%d %H:%M:%S")] $RESULT"
 
 echo $LOGLINE >> $LOGFILE
 

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,12 @@ Bash script to update the ip of an account on no-ip.com
 How to use
 ----------
 
-* Configure the script with the correct username, password, hostname, cache file (current IP), and log file
+* Configure the script with the correct username, password, hostname, and log file
 * Make it executable (`chmod +x`)
 * Run it (`./noipupdater.sh`)
 
 Tips!
 -----
-It may be useful to have DNS dig command installed. On Debian/Ubuntu based systems, install package with: `sudo apt install dnsutils`
 
 Place this in your cron file:
 


### PR DESCRIPTION
This removes the IP caching too, because it saves nothing: it avoided making a call to no-ip only by spending one to icanhazip.

If the IP hasn't changed, no-ip returns "nochg $IP", and that'll get logged.

This is the same change as https://github.com/mdmower/bash-no-ip-updater/pull/6